### PR TITLE
making wgconfig work with python 2.7

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,6 @@ setup_kwargs = {
     'packages': setuptools.find_packages(),
     'classifiers': [
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Operating System :: POSIX :: Linux',
         'Development Status :: 5 - Production/Stable',
@@ -25,7 +24,7 @@ setup_kwargs = {
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology'
     ],
-    'python_requires': '>=3.5',
+    'python_requires': '>=2.7',
     'keywords': 'WireGuard configuration config wg',
     'project_urls': {
         'Repository': 'https://www.github.com/towalink/wgconfig',

--- a/src/wgconfig/__init__.py
+++ b/src/wgconfig/__init__.py
@@ -2,6 +2,13 @@
 
 """wgconfig.py: A class for parsing and writing Wireguard configuration files."""
 
+from __future__ import with_statement
+from __future__ import absolute_import
+from __future__ import print_function
+from builtins import str
+from builtins import range
+from builtins import object
+from io import open
 __author__ = "Dirk Henrici"
 __license__ = "AGPL" # + author has right to release in parallel under different licenses
 __email__ = "towalink.wgconfig@henrici.name"
@@ -60,7 +67,7 @@ class WGConfig(object):
         attr, _, value = line.partition('=')
         attr = attr.strip()
         parts = value.partition('#')
-        value = parts[0].strip() # strip comments and whitespace
+        value = str(parts[0].strip()) # strip comments and whitespace
         comment = parts[1] + parts[2]
         if value.isnumeric():
             value = [int(value)]
@@ -76,7 +83,7 @@ class WGConfig(object):
         #_index_lastline: Line (zero indexed) of the last attribute line of the section (including any directly following comments)
 
         def close_section(section, section_data):
-            section_data = {k: (v if len(v) > 1 else v[0]) for k, v in section_data.items()}
+            section_data = dict((k, (v if len(v) > 1 else v[0])) for k, v in list(section_data.items()))
             if section is None: # nothing to close on first section
                 return
             elif section == 'interface': # close interface section
@@ -111,7 +118,7 @@ class WGConfig(object):
                     last_empty_line_in_section = None
                 section_data[self.SECTION_LASTLINE] = [i]
                 if not section in ['interface', 'peer']:
-                    raise ValueError(f'Unsupported section [{section}] in line {i}')
+                    raise ValueError('Unsupported section [%s] in line %d'%(section,i))
             elif line.startswith('#'):
                 section_data[self.SECTION_LASTLINE] = [i]
             else: # regular line
@@ -143,7 +150,7 @@ class WGConfig(object):
         self.handle_leading_comment(leading_comment) # add leading comment if needed
         # Append peer with key attribute
         self.lines.append('[Peer]')
-        self.lines.append(f'{self.keyattr} = {key}')
+        self.lines.append('%s = %s'%(self.keyattr,key))
         # Invalidate data cache
         self.invalidate_data()
 
@@ -195,7 +202,7 @@ class WGConfig(object):
         if (line_found is None) or append_as_line:
             line_found = section_lastline if (line_found is None) else line_found
             line_found += 1
-            self.lines.insert(line_found, f'{attr} = {value}')
+            self.lines.insert(line_found, '%s = %s'%(attr,value))
         else:
             line_attr, line_value, line_comment = self.parse_line(self.lines[line_found])
             line_value.append(value)

--- a/src/wgconfig/wgexec.py
+++ b/src/wgconfig/wgexec.py
@@ -2,6 +2,8 @@
 
 """Simple wrapper around WireGuard commands"""
 
+from __future__ import absolute_import
+from __future__ import print_function
 import logging
 import shlex
 import subprocess

--- a/test/test_1.py
+++ b/test/test_1.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import contextlib
+from __future__ import with_statement
+from __future__ import absolute_import
+from __future__ import print_function
 import filecmp
 import os
 import pprint
@@ -19,7 +21,12 @@ def setup_testconfig1(scope='module'):
     wc = wgconfig.WGConfig(file=TESTFILE1)
     wc.read_file()
     yield wc
-    with contextlib.suppress(FileNotFoundError):
+    # python2 compatibility
+    #   - no FileNotFoundError 
+    #   - no contextlib.suppres()
+    # import contextlib
+    # with contextlib.suppress(FileNotFoundError):
+    if os.path.exists(TESTFILE1_SAVED):
         os.unlink(TESTFILE1_SAVED)
 
 def output_data(wc):
@@ -64,7 +71,7 @@ def test_expected_peer_data(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 24}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers, 'data of peers needs to be correctly parsed'
 
@@ -75,7 +82,7 @@ def test_initialize_file(setup_testconfig1):
                  '_index_lastline': 0}
     del wc.interface['_rawdata']
     assert wc.interface == interface
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == dict()
 
@@ -87,7 +94,7 @@ def test_initialize_file_with_comment(setup_testconfig1):
                  '_index_lastline': 1}
     del wc.interface['_rawdata']
     assert wc.interface == interface
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == dict()
 
@@ -171,7 +178,7 @@ def test_add_peer(setup_testconfig1):
              '801mgm2JhjTOCxfihEknzFJGYxDvi+8oVYBrWe3hOWM=': {'PublicKey': '801mgm2JhjTOCxfihEknzFJGYxDvi+8oVYBrWe3hOWM=',
                                                              '_index_firstline': 26,
                                                              '_index_lastline': 27}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers, 'peer incorrectly added'
 
@@ -196,7 +203,7 @@ def test_add_peer_with_comment(setup_testconfig1):
              '801mgm2JhjTOCxfihEknzFJGYxDvi+8oVYBrWe3hOWM=': {'PublicKey': '801mgm2JhjTOCxfihEknzFJGYxDvi+8oVYBrWe3hOWM=',
                                                              '_index_firstline': 26,
                                                              '_index_lastline': 28}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers, 'peer (with comment) incorrectly added'
 
@@ -211,7 +218,7 @@ def test_del_peer1(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 8,
                                                              '_index_lastline': 15}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers, 'first peer incorrectly deleted'
     interface = {'Address': 'fe80::1/64',
@@ -233,7 +240,7 @@ def test_del_peer2(setup_testconfig1):
                                                              'PublicKey': 'XWItB4SR1qwGbGn59oRE6TBlTYHQF0pDy1x63dlr5nA=',
                                                              '_index_firstline': 8,
                                                              '_index_lastline': 15}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers, 'second peer incorrectly deleted'
     interface = {'Address': 'fe80::1/64',
@@ -264,7 +271,7 @@ def test_add_attr1(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 24}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -288,7 +295,7 @@ def test_add_attr2(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 18,
                                                              '_index_lastline': 25}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -312,7 +319,7 @@ def test_add_attr3(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 25}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -336,7 +343,7 @@ def test_add_attr4(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 26}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -360,7 +367,7 @@ def test_add_attr5(setup_testconfig1):
                                                              'TestAttr': 42,
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 25}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -384,7 +391,7 @@ def test_add_attr6(setup_testconfig1):
                                                              'TestAttr': 42,
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 26}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -405,7 +412,7 @@ def test_del_attr1(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 16,
                                                              '_index_lastline': 23}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -426,7 +433,7 @@ def test_del_attr2(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 22}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -448,7 +455,7 @@ def test_del_attr3(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 22}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -470,7 +477,7 @@ def test_del_attr4(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 23}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -492,7 +499,7 @@ def test_del_attr5(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 24}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
     
@@ -514,7 +521,7 @@ def test_del_attr6(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 23}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers
     
@@ -536,6 +543,6 @@ def test_del_attr7(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 23}}
-    for peer in wc.peers.values():
+    for peer in list(wc.peers.values()):
         del peer['_rawdata']
     assert wc.peers == peers

--- a/test/test_1.py
+++ b/test/test_1.py
@@ -71,7 +71,7 @@ def test_expected_peer_data(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 24}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers, 'data of peers needs to be correctly parsed'
 
@@ -82,7 +82,7 @@ def test_initialize_file(setup_testconfig1):
                  '_index_lastline': 0}
     del wc.interface['_rawdata']
     assert wc.interface == interface
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == dict()
 
@@ -94,7 +94,7 @@ def test_initialize_file_with_comment(setup_testconfig1):
                  '_index_lastline': 1}
     del wc.interface['_rawdata']
     assert wc.interface == interface
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == dict()
 
@@ -178,7 +178,7 @@ def test_add_peer(setup_testconfig1):
              '801mgm2JhjTOCxfihEknzFJGYxDvi+8oVYBrWe3hOWM=': {'PublicKey': '801mgm2JhjTOCxfihEknzFJGYxDvi+8oVYBrWe3hOWM=',
                                                              '_index_firstline': 26,
                                                              '_index_lastline': 27}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers, 'peer incorrectly added'
 
@@ -203,7 +203,7 @@ def test_add_peer_with_comment(setup_testconfig1):
              '801mgm2JhjTOCxfihEknzFJGYxDvi+8oVYBrWe3hOWM=': {'PublicKey': '801mgm2JhjTOCxfihEknzFJGYxDvi+8oVYBrWe3hOWM=',
                                                              '_index_firstline': 26,
                                                              '_index_lastline': 28}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers, 'peer (with comment) incorrectly added'
 
@@ -218,7 +218,7 @@ def test_del_peer1(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 8,
                                                              '_index_lastline': 15}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers, 'first peer incorrectly deleted'
     interface = {'Address': 'fe80::1/64',
@@ -240,7 +240,7 @@ def test_del_peer2(setup_testconfig1):
                                                              'PublicKey': 'XWItB4SR1qwGbGn59oRE6TBlTYHQF0pDy1x63dlr5nA=',
                                                              '_index_firstline': 8,
                                                              '_index_lastline': 15}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers, 'second peer incorrectly deleted'
     interface = {'Address': 'fe80::1/64',
@@ -271,7 +271,7 @@ def test_add_attr1(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 24}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -295,7 +295,7 @@ def test_add_attr2(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 18,
                                                              '_index_lastline': 25}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -319,7 +319,7 @@ def test_add_attr3(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 25}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -343,7 +343,7 @@ def test_add_attr4(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 26}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -367,7 +367,7 @@ def test_add_attr5(setup_testconfig1):
                                                              'TestAttr': 42,
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 25}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -391,7 +391,7 @@ def test_add_attr6(setup_testconfig1):
                                                              'TestAttr': 42,
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 26}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -412,7 +412,7 @@ def test_del_attr1(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 16,
                                                              '_index_lastline': 23}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -433,7 +433,7 @@ def test_del_attr2(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 22}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -455,7 +455,7 @@ def test_del_attr3(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 22}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -477,7 +477,7 @@ def test_del_attr4(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 23}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
 
@@ -499,7 +499,7 @@ def test_del_attr5(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 24}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
     
@@ -521,7 +521,7 @@ def test_del_attr6(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 23}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers
     
@@ -543,6 +543,6 @@ def test_del_attr7(setup_testconfig1):
                                                              'PublicKey': 'eBvBVLo6wH0XkBfIjeLPf8ydBTfU/gMqJOH4nmVXcDE=',
                                                              '_index_firstline': 17,
                                                              '_index_lastline': 23}}
-    for peer in list(wc.peers.values()):
+    for peer in wc.peers.values():
         del peer['_rawdata']
     assert wc.peers == peers


### PR DESCRIPTION
To make things work with python 2.7:

- minor changes from p3 f-strings and other str handling so it works with p2.7
- ran `3to2 -x str` to make p3-to-p2 adjustments
- ran `futurize` to undo a few p3-to-p2 adjustments
- eliminated use of contextlib.suppress and instead do a basic os.path.exist()->os.unlink

The resulting changes pass running `pytest` for both python 2.7 and python 3.6 on a CentOS 7 machine. 

No further testing has been done!

Let me know what you think.